### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,6 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run format
       - run: pnpm run test
-      - run: npm publish
+      - run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm run lint
+      - run: pnpm run format
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
       - run: pnpm run build
       - run: pnpm run lint
       - run: pnpm run format
+      - run: pnpm run test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow is triggered by pushing tags matching the pattern `v*.*.*` and performs a series of steps to prepare and publish the release.

### New GitHub Actions Workflow:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R22): Added a `release` workflow that runs on `ubuntu-latest` and includes steps for checking out the repository, setting up `pnpm`, installing dependencies, building the project, running linting and formatting checks, and publishing the package to npm using an authentication token.